### PR TITLE
Endret til docker-build-push

### DIFF
--- a/.github/workflows/build_n_deploy.yaml
+++ b/.github/workflows/build_n_deploy.yaml
@@ -6,9 +6,6 @@ on:
     branches:
       - 'main'
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
-
 permissions:
   contents: read
   packages: write
@@ -32,19 +29,20 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
       - name: Yarn build
         run: yarn build
-      - name: Build and publish Docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker build . -t ${IMAGE}
-          echo ${GITHUB_TOKEN} | docker login ghcr.io --username ${GITHUB_REPOSITORY} --password-stdin
-          docker push ${IMAGE}
+      - uses: nais/docker-build-push@v0
+        id: docker-push
+        with:
+          team: tilleggsstonader
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
       - name: Post deploy failures to Slack
         if: github.ref == 'refs/heads/main' && failure()
         run: |
           curl -X POST --data "{\"text\": \"Build av $GITHUB_REPOSITORY feilet - $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" $WEBHOOK_URL
         env:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    outputs:
+      image: ${{ steps.docker-push.outputs.image }}
   deploy:
     name: Deploy to NAIS
     needs: build
@@ -55,6 +53,7 @@ jobs:
         env:
           CLUSTER: prod-gcp
           RESOURCE: nais/gcp-prod.yaml
+          IMAGE: ${{ needs.build.outputs.image }}
       - name: Post deploy failures to Slack
         if: github.ref == 'refs/heads/main' && failure()
         run: |


### PR DESCRIPTION
Man får varningsmelding på https://console.nav.cloud.nais.io/team/tilleggsstonader/dev-gcp/app/tilleggsstonader-sak-frontend/status når man bruker ghcr. 
`docker-build-push` pusher til GAR
> Deprecated image registry ghcr.io for image tilleggsstonader-sak-frontend. See [docker-build-push](https://doc.nais.io/guides/oci-migration/) on how to migrate to Google Artifact Registry."

https://doc.nais.io/guides/oci-migration/?h=docker+build+push#build-and-publish-docker-image